### PR TITLE
Remove H2 dependency from the keyrotation-tool

### DIFF
--- a/components/org.wso2.carbon.identity.keyrotation/pom.xml
+++ b/components/org.wso2.carbon.identity.keyrotation/pom.xml
@@ -52,11 +52,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>${h2.version}</version>
-        </dependency>
-        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>${mysql-connector-java.version}</version>
@@ -180,7 +175,6 @@
         <gson.version>2.8.5</gson.version>
         <commons-lang.version>2.6.0.wso2v1</commons-lang.version>
         <axiom.version>1.2.11.wso2v13</axiom.version>
-        <h2.version>1.4.199</h2.version>
         <mysql-connector-java.version>5.1.46</mysql-connector-java.version>
         <jcc.version>11.5.5.0</jcc.version>
         <postgresql.version>42.2.19</postgresql.version>


### PR DESCRIPTION
This PR removes redundant H2 dependency from the `keyrotation-tool` component.