### PR TITLE
Add a config for workflow tables in key rotation tool

### DIFF
--- a/components/org.wso2.carbon.identity.keyrotation/src/main/java/org.wso2.carbon.identity.keyrotation/config/FileBasedKeyRotationConfigProvider.java
+++ b/components/org.wso2.carbon.identity.keyrotation/src/main/java/org.wso2.carbon.identity.keyrotation/config/FileBasedKeyRotationConfigProvider.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ * Copyright (c) (2021-2024), WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -79,6 +79,9 @@ public class FileBasedKeyRotationConfigProvider implements KeyRotationConfigProv
             logger.log(Level.WARN, "Not a valid number. Falling back to default chunk size.", e);
             keyRotationConfig.setChunkSize(DBConstants.DEFAULT_CHUNK_SIZE);
         }
+        String enableWorkflowMigrator =
+                StringUtils.isNotBlank(properties.getProperty(KeyRotationConstants.ENABLE_WORKFLOW_MIGRATOR)) ?
+                properties.getProperty(KeyRotationConstants.ENABLE_WORKFLOW_MIGRATOR) : "true";
 
         configValidator.validateFilePath(KeyRotationConstants.NEW_IS_HOME, newISHome);
         configValidator.validateURI(KeyRotationConstants.OLD_IDN_DB_URL, oldIdnDBUrl);
@@ -87,6 +90,7 @@ public class FileBasedKeyRotationConfigProvider implements KeyRotationConfigProv
         configValidator.validateBoolean(KeyRotationConstants.ENABLE_DB_MIGRATOR, enableDBMigrator);
         configValidator.validateBoolean(KeyRotationConstants.ENABLE_CONFIG_MIGRATOR, enableConfigMigrator);
         configValidator.validateBoolean(KeyRotationConstants.ENABLE_SYNC_MIGRATOR, enableSyncMigrator);
+        configValidator.validateBoolean(KeyRotationConstants.ENABLE_WORKFLOW_MIGRATOR, enableWorkflowMigrator);
 
         keyRotationConfig.setOldSecretKey(oldSecretKey);
         keyRotationConfig.setNewSecretKey(newSecretKey);
@@ -103,6 +107,7 @@ public class FileBasedKeyRotationConfigProvider implements KeyRotationConfigProv
         keyRotationConfig.setEnableDBMigrator(Boolean.parseBoolean(enableDBMigrator));
         keyRotationConfig.setEnableConfigMigrator(Boolean.parseBoolean(enableConfigMigrator));
         keyRotationConfig.setEnableSyncMigrator(Boolean.parseBoolean(enableSyncMigrator));
+        keyRotationConfig.setEnableWorkflowMigrator(Boolean.parseBoolean(enableWorkflowMigrator));
     }
 
     /**

--- a/components/org.wso2.carbon.identity.keyrotation/src/main/java/org.wso2.carbon.identity.keyrotation/config/model/KeyRotationConfig.java
+++ b/components/org.wso2.carbon.identity.keyrotation/src/main/java/org.wso2.carbon.identity.keyrotation/config/model/KeyRotationConfig.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) (2021-2024), WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -42,6 +42,7 @@ public class KeyRotationConfig {
     private boolean enableDBMigrator;
     private boolean enableConfigMigrator;
     private boolean enableSyncMigrator;
+    private boolean enableWorkflowMigrator;
 
     public static KeyRotationConfig getInstance() {
 
@@ -366,5 +367,25 @@ public class KeyRotationConfig {
     public void setEnableSyncMigrator(boolean enableSyncMigrator) {
 
         this.enableSyncMigrator = enableSyncMigrator;
+    }
+
+    /**
+     * Get for the enable workflow migrator property value.
+     *
+     * @return Enable syncing migrator property value.
+     */
+    public boolean getEnableWorkflowMigrator() {
+
+        return enableWorkflowMigrator;
+    }
+
+    /**
+     * Set for the enable workflow migrator property value.
+     *
+     * @param enableWorkflowMigrator Enable workflow migrator property value.
+     */
+    public void setEnableWorkflowMigrator(boolean enableWorkflowMigrator) {
+
+        this.enableWorkflowMigrator = enableWorkflowMigrator;
     }
 }

--- a/components/org.wso2.carbon.identity.keyrotation/src/main/java/org.wso2.carbon.identity.keyrotation/config/model/KeyRotationConfig.java
+++ b/components/org.wso2.carbon.identity.keyrotation/src/main/java/org.wso2.carbon.identity.keyrotation/config/model/KeyRotationConfig.java
@@ -372,7 +372,7 @@ public class KeyRotationConfig {
     /**
      * Get for the enable workflow migrator property value.
      *
-     * @return Enable syncing migrator property value.
+     * @return Enable workflow migrator property value.
      */
     public boolean getEnableWorkflowMigrator() {
 

--- a/components/org.wso2.carbon.identity.keyrotation/src/main/java/org.wso2.carbon.identity.keyrotation/service/DBKeyRotator.java
+++ b/components/org.wso2.carbon.identity.keyrotation/src/main/java/org.wso2.carbon.identity.keyrotation/service/DBKeyRotator.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) (2021-2024), WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -84,12 +84,14 @@ public class DBKeyRotator {
                 OAuthDAO.updateSecretCount);
         log.info("Failed OAuth consumer secret data records in IDN_OAUTH_CONSUMER_APPS: " +
                 OAuthDAO.failedUpdateSecretCount);
-        reEncryptBPSData(keyRotationConfig);
-        log.info("Successfully updated BPS profile data records in WF_BPS_PROFILE: " + BPSProfileDAO.updateCount);
-        log.info("Failed BPS profile data records in WF_BPS_PROFILE: " + BPSProfileDAO.failedUpdateCount);
-        reEncryptWFRequestData(keyRotationConfig);
-        log.info("Successfully updated WF request data records in WF_REQUEST: " + WorkFlowDAO.updateCount);
-        log.info("Failed WF request data records in WF_REQUEST: " + WorkFlowDAO.failedUpdateCount);
+        if (keyRotationConfig.getEnableWorkflowMigrator()) {
+            reEncryptBPSData(keyRotationConfig);
+            log.info("Successfully updated BPS profile data records in WF_BPS_PROFILE: " + BPSProfileDAO.updateCount);
+            log.info("Failed BPS profile data records in WF_BPS_PROFILE: " + BPSProfileDAO.failedUpdateCount);
+            reEncryptWFRequestData(keyRotationConfig);
+            log.info("Successfully updated WF request data records in WF_REQUEST: " + WorkFlowDAO.updateCount);
+            log.info("Failed WF request data records in WF_REQUEST: " + WorkFlowDAO.failedUpdateCount);
+        }
         reEncryptKeystorePasswordData(keyRotationConfig);
         log.info("Successfully updated keystore password property data records in REG_PROPERTY: " +
                 RegistryDAO.updateCount);

--- a/components/org.wso2.carbon.identity.keyrotation/src/main/java/org.wso2.carbon.identity.keyrotation/util/KeyRotationConstants.java
+++ b/components/org.wso2.carbon.identity.keyrotation/src/main/java/org.wso2.carbon.identity.keyrotation/util/KeyRotationConstants.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) (2021-2024), WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -43,6 +43,7 @@ public class KeyRotationConstants {
     public static final String ENABLE_DB_MIGRATOR = "enableDBMigrator";
     public static final String ENABLE_CONFIG_MIGRATOR = "enableConfigMigrator";
     public static final String ENABLE_SYNC_MIGRATOR = "enableSyncMigrator";
+    public static final String ENABLE_WORKFLOW_MIGRATOR = "enableWorkflowMigrator";
 
     public static final String ALGORITHM = "AES";
     public static final String TRANSFORMATION = "AES/GCM/NoPadding";


### PR DESCRIPTION
## Purpose
Since IS 7.0.0, workflow tables are not is the database by default. Hence introducing a config for key tool to disable workflow table migration in IS 7.

Add the following config to `properties.yaml` in IS 7.0
```
enableWorkflowMigrator: false
```
The config is enabled by default for backward compatilility.