### PR TITLE
Update pr-builder.yml bump actions/cache version and add jdk 11 and 17 builds

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -26,7 +26,7 @@ jobs:
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-m2
         with:

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -17,9 +17,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+          matrix:
+            java-version: [ 11, 17 ]
+            
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Adopt JDK 8
+      - name: Set up Adopt JDK 11 and 17
         uses: actions/setup-java@v2
         with:
           java-version: "8"


### PR DESCRIPTION
## Purpose
> Bump actions/cache version since v2 is deprecated.

## Related Issue 
- https://github.com/wso2/product-is/issues/23500